### PR TITLE
Allow api arguments to albums and photos requests

### DIFF
--- a/lib/picasa.rb
+++ b/lib/picasa.rb
@@ -5,12 +5,12 @@ require "picasa/version"
 module Picasa
   def self.albums(options = {})
     web_albums = Picasa::WebAlbums.new(options[:google_user])
-    web_albums.albums
+    web_albums.albums options.except( :google_user )
   end
 
   def self.photos(options = {})
     raise ArgumentError.new("You must specify album_id") unless options[:album_id]
     web_albums = Picasa::WebAlbums.new(options[:google_user])
-    web_albums.photos(options[:album_id])
+    web_albums.photos(options[:album_id], options.except( :album_id ))
   end
 end

--- a/lib/picasa/web_albums.rb
+++ b/lib/picasa/web_albums.rb
@@ -8,8 +8,8 @@ module Picasa
       raise ArgumentError.new("You must specify google_user") unless Picasa.config.google_user
     end
 
-    def albums
-      data = connect("/data/feed/api/user/#{Picasa.config.google_user}")
+    def albums opts=nil
+      data = connect("/data/feed/api/user/#{Picasa.config.google_user}", opts)
       xml = XmlSimple.xml_in(data)
       albums = []
       xml["entry"].each do |album|
@@ -26,8 +26,8 @@ module Picasa
       albums
     end
 
-    def photos(album_id)
-      data = connect("/data/feed/api/user/#{Picasa.config.google_user}/albumid/#{album_id}")
+    def photos(album_id, opts=nil)
+      data = connect("/data/feed/api/user/#{Picasa.config.google_user}/albumid/#{album_id}", opts)
       xml = XmlSimple.xml_in(data)
       photos = []
       xml["entry"].each do |photo|
@@ -45,8 +45,8 @@ module Picasa
 
     private
 
-    def connect(url)
-      full_url = "http://picasaweb.google.com" + url
+    def connect(url, opts=nil)
+      full_url = "http://picasaweb.google.com#{ url }?#{ opts.try( :to_query ) }"
       Net::HTTP.get(URI.parse(full_url))
     end
   end


### PR DESCRIPTION
Added this for a project I am doing. It allow you to do stuff like:

```
Picasa.albums :thumbsize => '32c'
Picasa.photos ALBUM_ID, :imgmax => '720'
```

Still need to write some tests.
