### PR TITLE
Photo id retrieved incorrectly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+.DS_Store

--- a/lib/picasa/presenter/photo.rb
+++ b/lib/picasa/presenter/photo.rb
@@ -20,7 +20,7 @@ module Picasa
 
       # @return [String]
       def id
-        @id ||= safe_retrieve(parsed_body, "gphoto$id").last
+        @id ||= safe_retrieve(parsed_body, "gphoto$id")
       end
 
       # @return [String]


### PR DESCRIPTION
Hi morgoth,

I'm using your excellent gem in one of my projects and since I've upgraded to 0.6.0 I've been getting an error while trying to delete a previously retrieved image:

```
old_image = @client.album.show(album.id).entries.find { |photo| photo.summary == image_type }
@client.photo.destroy(album.id, old_image.id) if old_image
```

The above code throws a **Picasa::NotFoundError (Invalid PhotoId)**, so I've done a bit of digging around and I found a small error in [photo presenter](https://github.com/morgoth/picasa/blob/master/lib/picasa/presenter/photo.rb#L23).

Line 23 should be:

```
@id ||= safe_retrieve(parsed_body, "gphoto$id")
```

instead of

```
@id ||= safe_retrieve(parsed_body, "gphoto$id").last
```

Please see the attached commit.

Thanks,
icflorescu
