### PR TITLE
Add tests for album keywords and keywords not set

### DIFF
--- a/lib/picasa/presenter/album.rb
+++ b/lib/picasa/presenter/album.rb
@@ -55,6 +55,11 @@ module Picasa
       end
 
       # @return [String]
+      def keywords
+        @keywords ||= safe_retrieve(parsed_body, "media$keywords")
+      end
+
+      # @return [String]
       def id
         @id ||= safe_retrieve(parsed_body, "gphoto$id")
       end

--- a/test/api/album_test.rb
+++ b/test/api/album_test.rb
@@ -131,6 +131,10 @@ describe Picasa::API::Album do
       assert_equal "public", @album.access
     end
 
+    it "has keywords" do
+      assert_equal "keywords", @album.keywords
+    end
+
     it "has timestamp" do
       assert_equal "1219906800000", @album.timestamp
     end


### PR DESCRIPTION
Allow to access album keywords and add test showing an issue where keywords are not set.
