### PR TITLE
Added method to get the cover_image of the album

### DIFF
--- a/lib/picasa/presenter/media.rb
+++ b/lib/picasa/presenter/media.rb
@@ -9,6 +9,11 @@ module Picasa
       end
 
       # @return [String]
+      def cover_photo_url
+        @cover_photo_url ||= parsed_body['media$content'][0]['url']
+      end
+
+      # @return [String]
       def credit
         @credit ||= parsed_body["media$credit"][0]["$t"]
       end

--- a/test/api/album_test.rb
+++ b/test/api/album_test.rb
@@ -58,6 +58,11 @@ describe Picasa::API::Album do
       assert_equal "Wojciech Wnętrzak", @album_list.nickname
     end
 
+    it "has cover_photo" do
+      expected = "https://lh6.googleusercontent.com/-ZqXRf3HicvI/SLakNnjixrE/AAAAAAAAAkc/3EAZ0eF3-CQ/Test.jpg"
+      assert_equal expected, @album_list.albums[0].media.cover_photo_url
+    end
+
     it "has thumbnail" do
       expected = "https://lh3.googleusercontent.com/-6ezHc54U8x0/AAAAAAAAAAI/AAAAAAAAAAA/PBuxm7Ehn6E/s64-c/106136347770555028022.jpg"
       assert_equal expected, @album_list.thumbnail


### PR DESCRIPTION
It adds a method `cover_image_url` in the `Media` presenter which gives the full size cover image of the album from the `album.list.albums`  rather than just the thumbnail which is provided by `Thumbnail` presenter.